### PR TITLE
Cater for test ids as well as translation issues on autocomplete component

### DIFF
--- a/src/Components/AutoComplete.tsx
+++ b/src/Components/AutoComplete.tsx
@@ -33,12 +33,12 @@ function AutoComplete(props: AutoCompleteProps) {
       <Surface style={styles.containerStyle}>
         <Appbar.Header>
           <Appbar.Action 
-            testID={`${ props.textInputProps?.label }Close`}
+            testID={`${ props.textInputProps?.testID }Close`}
             icon={'close'}
             onPress={() => setVisible(false)} />
           <Appbar.Content title={textInputProps?.label} />
           <Appbar.Action
-            testID={`${ props.textInputProps?.label }Check`}
+            testID={`${ props.textInputProps?.testID }Check`}
             icon={'check'}
             disabled={!selectedValue}
             onPress={() => {
@@ -50,7 +50,7 @@ function AutoComplete(props: AutoCompleteProps) {
         <SafeAreaView style={styles.containerStyle}>
           <View style={styles.searchStyle}>
             <Searchbar
-              testID={`${ props.textInputProps?.label }SearchBar`}
+              testID={`${ props.textInputProps?.testID }SearchBar`}
               value={search}
               onChangeText={setSearch}
               placeholder={props.textInputProps?.placeholder ? props.textInputProps.placeholder : `Search ${ textInputProps?.label ?? "" }`}

--- a/src/Components/AutoComplete.tsx
+++ b/src/Components/AutoComplete.tsx
@@ -32,9 +32,13 @@ function AutoComplete(props: AutoCompleteProps) {
     <Modal visible={visible} onDismiss={() => setVisible(false)}>
       <Surface style={styles.containerStyle}>
         <Appbar.Header>
-          <Appbar.Action icon={'close'} onPress={() => setVisible(false)} />
+          <Appbar.Action 
+            testID={`${ props.textInputProps?.label }Close`}
+            icon={'close'}
+            onPress={() => setVisible(false)} />
           <Appbar.Content title={textInputProps?.label} />
           <Appbar.Action
+            testID={`${ props.textInputProps?.label }Check`}
             icon={'check'}
             disabled={!selectedValue}
             onPress={() => {
@@ -46,9 +50,10 @@ function AutoComplete(props: AutoCompleteProps) {
         <SafeAreaView style={styles.containerStyle}>
           <View style={styles.searchStyle}>
             <Searchbar
+              testID={`${ props.textInputProps?.label }SearchBar`}
               value={search}
               onChangeText={setSearch}
-              placeholder={`Search ${textInputProps?.label ?? ''}`}
+              placeholder={props.textInputProps?.placeholder ? props.textInputProps.placeholder : `Search ${ textInputProps?.label ?? "" }`}
             />
           </View>
           <FlatList


### PR DESCRIPTION
I was having issues with Detox not being able to find my components, resorting all kinds of crazy.

I've tested this and it works.  I can now easily use detox to open the auto complete, type in the search box, find an item and click the check to select it.

I also saw that "Search" was prepended to the label, to give the user a place holder to search for their item.  We're going to use this on multiple languages so I thought it might be best if the dev can rather pass in a placeholder.