### PR TITLE
autoDismiss prop in auto complete input type

### DIFF
--- a/src/Components/AutoComplete.tsx
+++ b/src/Components/AutoComplete.tsx
@@ -11,7 +11,8 @@ import {
 import {AutoCompleteProps} from '../Types/Types';
 
 function AutoComplete(props: AutoCompleteProps) {
-  const {visible, setVisible, textInputProps, options, field} = props;
+  const {visible, setVisible, textInputProps, options, field, autoDismiss} =
+    props;
   const theme = useTheme();
   const styles = useMemo(
     () =>
@@ -32,13 +33,14 @@ function AutoComplete(props: AutoCompleteProps) {
     <Modal visible={visible} onDismiss={() => setVisible(false)}>
       <Surface style={styles.containerStyle}>
         <Appbar.Header>
-          <Appbar.Action 
-            testID={`${ props.textInputProps?.testID }Close`}
+          <Appbar.Action
+            testID={`${props.textInputProps?.testID}Close`}
             icon={'close'}
-            onPress={() => setVisible(false)} />
+            onPress={() => setVisible(false)}
+          />
           <Appbar.Content title={textInputProps?.label} />
           <Appbar.Action
-            testID={`${ props.textInputProps?.testID }Check`}
+            testID={`${props.textInputProps?.testID}Check`}
             icon={'check'}
             disabled={!selectedValue}
             onPress={() => {
@@ -50,10 +52,14 @@ function AutoComplete(props: AutoCompleteProps) {
         <SafeAreaView style={styles.containerStyle}>
           <View style={styles.searchStyle}>
             <Searchbar
-              testID={`${ props.textInputProps?.testID }SearchBar`}
+              testID={`${props.textInputProps?.testID}SearchBar`}
               value={search}
               onChangeText={setSearch}
-              placeholder={props.textInputProps?.placeholder ? props.textInputProps.placeholder : `Search ${ textInputProps?.label ?? "" }`}
+              placeholder={
+                props.textInputProps?.placeholder
+                  ? props.textInputProps.placeholder
+                  : `Search ${textInputProps?.label ?? ''}`
+              }
             />
           </View>
           <FlatList
@@ -66,6 +72,10 @@ function AutoComplete(props: AutoCompleteProps) {
                 title={item.label}
                 onPress={() => {
                   setSelectedValue(`${item.value}`);
+                  if (autoDismiss) {
+                    field.onChange(`${item.value}`);
+                    setVisible(false);
+                  }
                 }}
                 titleStyle={{
                   color:

--- a/src/Inputs/InputAutocomplete.tsx
+++ b/src/Inputs/InputAutocomplete.tsx
@@ -17,11 +17,13 @@ function InputAutocomplete(props: InputAutocompleteProps) {
     options,
     CustomAutoComplete,
     CustomTextInput,
+    autoDismiss,
   } = props;
   const theme = useTheme();
   const errorMessage = formState.errors?.[field.name]?.message;
   const textColor = errorMessage ? theme.colors.error : theme.colors.text;
   const [visible, setVisible] = useState(false);
+  const dismiss = autoDismiss ?? false;
   const AUTOCOMPLETE = CustomAutoComplete ?? AutoComplete;
   const INPUT = CustomTextInput ?? TextInput;
 
@@ -65,6 +67,7 @@ function InputAutocomplete(props: InputAutocompleteProps) {
         options={options}
         field={field}
         textInputProps={textInputProps}
+        autoDismiss={dismiss}
       />
       {errorMessage && <HelperText type={'error'}>{errorMessage}</HelperText>}
     </Fragment>

--- a/src/Types/Types.ts
+++ b/src/Types/Types.ts
@@ -59,6 +59,7 @@ export type InputAutocompleteProps = {
   options: OPTIONS;
   CustomAutoComplete?: typeof AutoComplete;
   CustomTextInput?: any;
+  autoDismiss?: boolean;
 };
 
 export type AutoCompleteProps = {
@@ -67,6 +68,7 @@ export type AutoCompleteProps = {
   textInputProps?: ComponentProps<typeof TextInput>;
   options: OPTIONS;
   field: ControllerRenderProps<FieldValues, string>;
+  autoDismiss: boolean;
 };
 
 export type InputSelectProps = {


### PR DESCRIPTION
The user might want to close the modal after selecting a value in the AutoComplete input type to avoid having to click the action button in the top right corner.

I added an optional `autoDismiss` prop which if set to true automatically closes the modal. and omitting it or setting it to false shows the default behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `autoDismiss` feature for autocomplete components, allowing for automatic dismissal of suggestions upon selection.
- **Refactor**
	- Updated `AutoComplete` and `InputAutocomplete` components to support the new `autoDismiss` property.
- **Documentation**
	- Added documentation for the `autoDismiss` property in autocomplete components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->